### PR TITLE
Move device address from generic arguments in initializer to function arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tmp117"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
-authors = ["xgroleau <xavgroleau@gmail.com>"]
+authors = ["xgroleau <xavgroleau@gmail.com>", "phansel <github@paulhansel.com>"]
 repository = "https://github.com/xgroleau/tmp117-rs"
 license = "MIT OR Apache-2.0"
 homepage= "https://github.com/xgroleau/tmp117-rs"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The low level api is always available if needed.
 
 ```rust
 // Pass the address of the tmp device
-let tmp = Tmp117::<0x49, _, _, _>::new(spi);
+let tmp = Tmp117::<_, _, _>::new(spi, 0x49);
 let delay = Delay;
 tmp.reset(delay).unwrap();
 

--- a/examples/asynchronous.rs
+++ b/examples/asynchronous.rs
@@ -16,7 +16,7 @@ async fn main(_spawner: Spawner) {
     let irq = interrupt::take!(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0);
     let twi = Twim::new(p.TWISPI0, irq, p.P1_10, p.P1_11, Default::default());
 
-    let mut tmp = Tmp117::<0x49, _, _, _>::new(twi);
+    let mut tmp = Tmp117::<_, _, _>::new(twi, 0x49_u8);
 
     // Read and goes to shutdown mode
     info!("Reading temp once");

--- a/examples/asynchronous.rs
+++ b/examples/asynchronous.rs
@@ -16,7 +16,7 @@ async fn main(_spawner: Spawner) {
     let irq = interrupt::take!(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0);
     let twi = Twim::new(p.TWISPI0, irq, p.P1_10, p.P1_11, Default::default());
 
-    let mut tmp = Tmp117::<_, _, _>::new(twi, 0x49_u8);
+    let mut tmp = Tmp117::<_, _, _>::new(twi, 0x49);
 
     // Read and goes to shutdown mode
     info!("Reading temp once");

--- a/examples/synchronous.rs
+++ b/examples/synchronous.rs
@@ -16,7 +16,7 @@ async fn main(_spawner: Spawner) {
     let irq = interrupt::take!(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0);
     let twi = Twim::new(p.TWISPI0, irq, p.P1_10, p.P1_11, Default::default());
 
-    let mut tmp = Tmp117::<_, _>::new(twi, 0x49_u8);
+    let mut tmp = Tmp117::<_, _>::new(twi, 0x49);
 
     // Read and goes to shutdown mode
     info!("Reading temp once");

--- a/examples/synchronous.rs
+++ b/examples/synchronous.rs
@@ -16,7 +16,7 @@ async fn main(_spawner: Spawner) {
     let irq = interrupt::take!(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0);
     let twi = Twim::new(p.TWISPI0, irq, p.P1_10, p.P1_11, Default::default());
 
-    let mut tmp = Tmp117::<0x49, _, _>::new(twi);
+    let mut tmp = Tmp117::<_, _>::new(twi, 0x49_u8);
 
     // Read and goes to shutdown mode
     info!("Reading temp once");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,19 +174,19 @@ where
     }
 
     fn set_oneshot(&mut self, average: Average) -> Result<(), Error<E>> {
-        let val = self.tmp_ll.edit(|r: &mut Configuration| {
+        self.tmp_ll.edit(|r: &mut Configuration| {
             r.set_mode(ConversionMode::OneShot);
             r.set_polarity(Polarity::ActiveLow);
             r.set_average(average);
         })?;
-        Ok(val)
+        Ok(())
     }
 
     fn set_shutdown(&mut self) -> Result<(), Error<E>> {
-        let val = self.tmp_ll.edit(|r: &mut Configuration| {
+        self.tmp_ll.edit(|r: &mut Configuration| {
             r.set_mode(ConversionMode::Shutdown);
         })?;
-        Ok(val)
+        Ok(())
     }
 
     /// Resets the device and put it in shutdown

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,25 +64,25 @@ pub struct Id {
 
 /// The TMP117 driver. Note that the alert pin is not used in this driver,
 /// see the async implementation if you want the driver to use the alert pin in the drive
-pub struct Tmp117<const ADDR: u8, T, E> {
-    tmp_ll: Tmp117LL<ADDR, T, E>,
+pub struct Tmp117<T, E> {
+    tmp_ll: Tmp117LL<T, E>,
 }
 
-impl<const ADDR: u8, T, E> Tmp117<ADDR, T, E>
+impl<T, E> Tmp117<T, E>
 where
     T: I2c<SevenBitAddress, Error = E>,
     E: embedded_hal::i2c::Error + Copy,
 {
     /// Create a new tmp117 from a i2c bus
-    pub fn new(i2c: T) -> Self {
-        Tmp117::<ADDR, T, E> {
-            tmp_ll: Tmp117LL::new(i2c),
+    pub fn new(i2c: T, addr: u8) -> Self {
+        Tmp117::<T, E> {
+            tmp_ll: Tmp117LL::new(i2c, addr),
         }
     }
 
     /// Create a new tmp117 from a low level tmp117 driver
-    pub fn new_from_ll(tmp_ll: Tmp117LL<ADDR, T, E>) -> Self {
-        Tmp117::<ADDR, T, E> { tmp_ll }
+    pub fn new_from_ll(tmp_ll: Tmp117LL<T, E>) -> Self {
+        Tmp117::<T, E> { tmp_ll }
     }
 
     /// Returns the ID of the device
@@ -149,7 +149,7 @@ where
     fn set_continuous(
         &mut self,
         config: ContinuousConfig,
-    ) -> Result<ContinuousHandler<'_, ADDR, T, E>, Error<E>> {
+    ) -> Result<ContinuousHandler<'_, T, E>, Error<E>> {
         if let Some(val) = config.high {
             let high: HighLimit = ((val / CELCIUS_CONVERSION) as u16).into();
             self.tmp_ll.write(high)?;
@@ -238,7 +238,7 @@ where
     /// and finally the device is shutdown
     pub fn continuous<F>(&mut self, config: ContinuousConfig, f: F) -> Result<(), Error<E>>
     where
-        F: FnOnce(ContinuousHandler<'_, ADDR, T, E>) -> Result<(), Error<E>>,
+        F: FnOnce(ContinuousHandler<'_, T, E>) -> Result<(), Error<E>>,
     {
         let handler = self.set_continuous(config)?;
         f(handler)?;
@@ -247,11 +247,11 @@ where
 }
 
 /// Handler for the continuous mode
-pub struct ContinuousHandler<'a, const ADDR: u8, T, E> {
-    tmp117: &'a mut Tmp117<ADDR, T, E>,
+pub struct ContinuousHandler<'a, T, E> {
+    tmp117: &'a mut Tmp117<T, E>,
 }
 
-impl<'a, const ADDR: u8, T, E> ContinuousHandler<'a, ADDR, T, E>
+impl<'a, T, E> ContinuousHandler<'a, T, E>
 where
     T: I2c<SevenBitAddress, Error = E>,
     E: embedded_hal::i2c::Error + Copy,

--- a/src/tmp117_ll.rs
+++ b/src/tmp117_ll.rs
@@ -8,26 +8,28 @@ use crate::error::ErrorLL;
 use crate::register::Address;
 
 /// The low level driver of the TPM117. Allows to read, write and edit the registers directly via the i2c bus
-pub struct Tmp117LL<const ADDR: u8, T, E> {
+pub struct Tmp117LL<T, E> {
     i2c: T,
+    addr: u8,
     e: PhantomData<E>,
 }
 
-impl<const ADDR: u8, T, E> Tmp117LL<ADDR, T, E>
+impl<T, E> Tmp117LL<T, E>
 where
     T: I2c<SevenBitAddress, Error = E>,
     E: embedded_hal::i2c::Error,
 {
     /// Creates a new instace of the Tmp117 from an i2c bus
-    pub fn new(i2c: T) -> Self {
+    pub fn new(i2c: T, addr: u8) -> Self {
         Self {
             i2c,
+            addr,
             e: PhantomData,
         }
     }
 }
 
-impl<const ADDR: u8, T, E, R> RegisterInterface<R, Address> for Tmp117LL<ADDR, T, E>
+impl<T, E, R> RegisterInterface<R, Address> for Tmp117LL<T, E>
 where
     R: Register<Address = Address> + Clone + TryFrom<u16>,
     u16: From<R>,
@@ -39,7 +41,7 @@ where
     fn read_register(&mut self) -> Result<R, Self::Error> {
         let mut buff = [0; 2];
         self.i2c
-            .write_read(ADDR, &[R::ADDRESS.0], &mut buff)
+            .write_read(self.addr, &[R::ADDRESS.0], &mut buff)
             .map_err(ErrorLL::Bus)?;
         let val = u16::from_be_bytes(buff[0..2].try_into().unwrap());
         R::try_from(val).map_err(|_| ErrorLL::InvalidData)
@@ -50,7 +52,7 @@ where
         let packet = val.to_be_bytes();
 
         self.i2c
-            .write(ADDR, &[R::ADDRESS.0, packet[0], packet[1]])
+            .write(self.addr, &[R::ADDRESS.0, packet[0], packet[1]])
             .map_err(ErrorLL::Bus)
     }
 }


### PR DESCRIPTION
It seems like the address was put into the generic arguments so as to potentially support I2C addresses other than SevenBitAddress in the future. However, these devices do not support anything other than 7-bit addresses. 

Having a `const u8` generic argument in the constructor also makes it somewhat inconvenient to instantiate multiple devices procedurally.

Something like the following will need to be added to Cargo.toml or .cargo/config.toml to allow the examples to be build conveniently.

```
+[dev-dependencies]
+embassy-nrf = { version = "0.2.0", features = ["nrf51"]}
+embassy-executor = "0.6.1"
+
+[[example]]
+name = "asynchronous"
+
+[[example]]
+name = "synchronous"
```