### PR TITLE
Fix/oneshot

### DIFF
--- a/src/asynchronous/mod.rs
+++ b/src/asynchronous/mod.rs
@@ -185,7 +185,21 @@ where
         Ok(())
     }
 
-    async fn wait_for_data(&mut self) -> Result<(), Error<E>> {
+    async fn wait_for_data<D>(&mut self, delay: &mut Option<D>, timeout: Option<usize>) -> Result<(), Error<E>>
+    where
+        D: DelayNs
+    {
+        // How long to wait between polls if delay is provided in ms
+        const POLL_DELAY: usize = 40;
+
+        // Calculate how many loops will result in a timeout
+        let mut timeout_count =
+            timeout.and_then(|tim| if (tim / POLL_DELAY) == 0 {
+                Some(1)
+            } else {
+                Some(tim / POLL_DELAY)
+            });
+
         // If we have a pin
         if let Some(AlertPin::DataReady(p)) = &mut self.alert {
             loop {
@@ -207,6 +221,16 @@ where
                 if config.data_ready() {
                     break;
                 }
+                if let Some(delay) = delay.as_mut() {
+                    delay.delay_ms(POLL_DELAY as u32).await;
+                }
+            if let Some(mut tim) = timeout_count {
+                tim -= 1;
+                if tim == 0 {
+                    return Err(Error::Timeout)
+                }
+                timeout_count = Some(tim);
+            }
             }
         }
         Ok(())
@@ -314,9 +338,12 @@ where
     }
 
     /// Wait for data and read the temperature in celsius and goes to shutdown since it's a oneshot
-    pub async fn oneshot(&mut self, average: Average) -> Result<f32, Error<E>> {
+    pub async fn oneshot<D>(&mut self, average: Average, delay: &mut D) -> Result<f32, Error<E>>
+    where
+        D: DelayNs
+    {
         self.set_oneshot(average).await?;
-        self.wait_for_data().await?;
+        self.wait_for_data(&mut Some(delay), Some(1000)).await?;
 
         let res = self.read_temp_raw().await?;
         self.set_shutdown().await?;
@@ -369,10 +396,13 @@ where
     }
 
     /// Wait for the data to be ready and read the temperature in celsius
-    pub async fn wait_temp(&mut self) -> Result<f32, Error<E>> {
+    pub async fn wait_temp<D>(&mut self) -> Result<f32, Error<E>>
+    where
+        D: DelayNs
+    {
         let tmp117 = unsafe { &mut *self.tmp117 };
         tmp117.set_data_ready().await?;
-        tmp117.wait_for_data().await?;
+        tmp117.wait_for_data::<D>(&mut None, None).await?;
         tmp117.read_temp_raw().await
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,9 @@ pub enum Error<E> {
 
     /// Received Invalid data
     InvalidData,
+
+    /// Waiting for data timed out
+    Timeout
 }
 
 /// Error emitted by the low level TMP117 drivers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,12 +124,34 @@ where
         }
     }
 
-    fn wait_for_data(&mut self) -> Result<(), Error<E>> {
+    fn wait_for_data<D>(&mut self, delay: &mut Option<D>, timeout: Option<usize>) -> Result<(), Error<E>>
+    where
+        D: DelayNs
+    {
+        // How long to wait between polls if delay is provided in ms
+        const POLL_DELAY: usize = 40;
+
+        // Calculate how many loops will result in a timeout
+        let mut timeout_count =
+            timeout.and_then(|tim| if (tim / POLL_DELAY) == 0 {
+                Some(1)
+            } else {
+                Some(tim / POLL_DELAY)
+            });
+
         // Loop while the data is not ok
         loop {
             let config: Configuration = self.tmp_ll.read()?;
             if config.data_ready() {
                 break;
+            }
+            delay.as_mut().and_then(|d| Some(d.delay_ms(POLL_DELAY as u32)));
+            if let Some(mut tim) = timeout_count {
+                tim -= 1;
+                if tim == 0 {
+                    return Err(Error::Timeout)
+                }
+                timeout_count = Some(tim);
             }
         }
         Ok(())
@@ -226,9 +248,13 @@ where
     }
 
     /// Wait for data and read the temperature in celsius and shutdown since it's a oneshot
-    pub fn oneshot(&mut self, average: Average) -> Result<f32, Error<E>> {
+    pub fn oneshot<D>(&mut self, average: Average, delay: &mut D) -> Result<f32, Error<E>>
+    where
+        D: DelayNs
+    {
         self.set_oneshot(average)?;
-        self.wait_for_data()?;
+        delay.delay_ms(100);
+        self.wait_for_data(&mut Some(delay), Some(1000))?;
         let data = self.read_temp_raw()?;
         Ok(data)
     }
@@ -268,8 +294,11 @@ where
     }
 
     /// Wait for the data to be ready and read the temperature in celsius
-    pub fn wait_temp(&mut self) -> Result<f32, Error<E>> {
-        self.tmp117.wait_for_data()?;
+    pub fn wait_temp<D>(&mut self) -> Result<f32, Error<E>>
+    where
+        D: DelayNs
+    {
+        self.tmp117.wait_for_data::<D>(&mut None, None)?;
         let val = self.tmp117.read_temp_raw()?;
         Ok(val)
     }


### PR DESCRIPTION
There is a known bug in the tmp117 where the data ready bit can end up never being read as high when the polling is too fast. Adding some delays and a way for the poll loop to timeout provides a workaround the issue.